### PR TITLE
Fix asset URLs leaking full filesystem path

### DIFF
--- a/includes/class-nre-migration-dashboard.php
+++ b/includes/class-nre-migration-dashboard.php
@@ -106,7 +106,7 @@ class NRE_Migration_Dashboard {
 
 		wp_enqueue_script(
 			'nre-migration-dashboard',
-			plugins_url( 'build/dashboard/index.js', __DIR__ ),
+			NRE_PLUGIN_URL . 'build/dashboard/index.js',
 			$asset['dependencies'],
 			$asset['version'],
 			true
@@ -114,7 +114,7 @@ class NRE_Migration_Dashboard {
 
 		wp_enqueue_style(
 			'nre-migration-dashboard',
-			plugins_url( 'build/dashboard/style-index.css', __DIR__ ),
+			NRE_PLUGIN_URL . 'build/dashboard/style-index.css',
 			[ 'wp-components' ],
 			$asset['version']
 		);

--- a/includes/class-nre-migration-ui.php
+++ b/includes/class-nre-migration-ui.php
@@ -82,7 +82,7 @@ class NRE_Migration_UI {
 
 		wp_enqueue_script(
 			'nre-revisions',
-			plugins_url( 'assets/js/nre-revisions.js', __DIR__ ),
+			NRE_PLUGIN_URL . 'assets/js/nre-revisions.js',
 			[ 'revisions' ],
 			NRE_VERSION,
 			true
@@ -90,7 +90,7 @@ class NRE_Migration_UI {
 
 		wp_enqueue_style(
 			'nre-revisions',
-			plugins_url( 'assets/css/nre-revisions.css', __DIR__ ),
+			NRE_PLUGIN_URL . 'assets/css/nre-revisions.css',
 			[ 'revisions' ],
 			NRE_VERSION
 		);

--- a/newspack-revisions-enhanced.php
+++ b/newspack-revisions-enhanced.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'NRE_VERSION', '0.1.0' );
 define( 'NRE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'NRE_PLUGIN_URL', set_url_scheme( WP_PLUGIN_URL . '/newspack-revisions-enhanced/' ) );
 define( 'NRE_TAX_META_PREFIX', '_nre_tax_' );
 
 require_once NRE_PLUGIN_DIR . 'includes/class-nre-meta-revisions.php';


### PR DESCRIPTION
## Summary
- Adds `NRE_PLUGIN_URL` constant built from `WP_PLUGIN_URL` + plugin slug, bypassing `plugin_basename()` path resolution
- Replaces all `plugins_url( '...', __DIR__ )` / `plugins_url( '...', NRE_PLUGIN_FILE )` calls with `NRE_PLUGIN_URL . '...'`
- Fixes 404s for dashboard JS/CSS and revisions screen assets when filesystem paths don't match `WP_PLUGIN_DIR`

Fixes #5

## Test plan
- [ ] Install plugin on a WordPress site and verify the Migrations dashboard loads (`Tools > Migrations`)
- [ ] Verify the revisions screen loads NRE assets (`/wp-admin/revision.php`)
- [ ] Check browser Network tab — asset URLs should be `{site}/wp-content/plugins/newspack-revisions-enhanced/...`