### PR TITLE
Fix rollback to restore post meta and capture correct revision values

### DIFF
--- a/includes/class-nre-migration-rollback.php
+++ b/includes/class-nre-migration-rollback.php
@@ -265,12 +265,15 @@ class NRE_Migration_Rollback {
 	}
 
 	/**
-	 * Restore all tracked meta from the pre-migration revision to the post.
+	 * Restore meta from the pre-migration revision to the post.
 	 *
 	 * Reads every meta row stored on the revision directly from the database
 	 * (bypassing object cache) and writes it to the parent post. NRE internal
 	 * meta (migration tags, taxonomy snapshots, post type) is excluded since
 	 * those are handled by dedicated restore methods or are revision-only data.
+	 *
+	 * Also deletes any tracked meta keys that were added during the migration
+	 * (present on the parent but absent from the pre-migration revision).
 	 *
 	 * @param int $post_id     The post ID.
 	 * @param int $revision_id The revision ID to restore meta from.
@@ -287,10 +290,6 @@ class NRE_Migration_Rollback {
 			)
 		);
 
-		if ( empty( $revision_meta ) ) {
-			return;
-		}
-
 		// Collect meta values per key (a key can have multiple rows).
 		$meta_by_key = [];
 		foreach ( $revision_meta as $row ) {
@@ -300,12 +299,7 @@ class NRE_Migration_Rollback {
 		// Keys that are NRE internal — stored on revisions for NRE's own
 		// tracking but should not be copied to the parent post.
 		$skip_prefixes = [ '_nre_migration_', NRE_TAX_META_PREFIX ];
-		$skip_exact    = [ '_nre_post_type' ];
-
-		// Get tracked meta keys so we can also delete keys that were added
-		// during the migration but don't exist on the pre-migration revision.
-		$post_type    = get_post_type( $post_id );
-		$tracked_keys = wp_post_revision_meta_keys( $post_type );
+		$skip_exact    = [ NRE_Post_Type_Revisions::META_KEY ];
 
 		foreach ( $meta_by_key as $meta_key => $values ) {
 			// Skip NRE internal meta.
@@ -335,6 +329,9 @@ class NRE_Migration_Rollback {
 
 		// Delete tracked meta keys that exist on the parent but were absent
 		// from the pre-migration revision (i.e., added during the migration).
+		$post_type    = get_post_type( $post_id );
+		$tracked_keys = wp_post_revision_meta_keys( $post_type );
+
 		foreach ( $tracked_keys as $meta_key ) {
 			if ( ! isset( $meta_by_key[ $meta_key ] ) ) {
 				delete_post_meta( $post_id, $meta_key );

--- a/includes/class-nre-migration-rollback.php
+++ b/includes/class-nre-migration-rollback.php
@@ -302,6 +302,11 @@ class NRE_Migration_Rollback {
 		$skip_prefixes = [ '_nre_migration_', NRE_TAX_META_PREFIX ];
 		$skip_exact    = [ '_nre_post_type' ];
 
+		// Get tracked meta keys so we can also delete keys that were added
+		// during the migration but don't exist on the pre-migration revision.
+		$post_type    = get_post_type( $post_id );
+		$tracked_keys = wp_post_revision_meta_keys( $post_type );
+
 		foreach ( $meta_by_key as $meta_key => $values ) {
 			// Skip NRE internal meta.
 			if ( in_array( $meta_key, $skip_exact, true ) ) {
@@ -325,6 +330,14 @@ class NRE_Migration_Rollback {
 				// Values from DB are raw (serialized if complex). Use add_metadata
 				// with wp_slash to match how _wp_copy_post_meta works.
 				add_metadata( 'post', $post_id, $meta_key, wp_slash( maybe_unserialize( $raw_value ) ) );
+			}
+		}
+
+		// Delete tracked meta keys that exist on the parent but were absent
+		// from the pre-migration revision (i.e., added during the migration).
+		foreach ( $tracked_keys as $meta_key ) {
+			if ( ! isset( $meta_by_key[ $meta_key ] ) ) {
+				delete_post_meta( $post_id, $meta_key );
 			}
 		}
 	}

--- a/includes/class-nre-migration-rollback.php
+++ b/includes/class-nre-migration-rollback.php
@@ -185,11 +185,13 @@ class NRE_Migration_Rollback {
 	}
 
 	/**
-	 * Execute the rollback: restore taxonomy, post type, then core fields.
+	 * Execute the rollback: restore taxonomy, post type, meta, then core fields.
 	 *
-	 * Order matters: taxonomy and post type are restored first so that
-	 * wp_restore_post_revision() creates a new revision that captures
-	 * the already-restored state via NRE's _wp_put_post_revision hooks.
+	 * Order matters: taxonomy, post type, and meta are restored BEFORE
+	 * wp_restore_post_revision() so that the new revision it creates
+	 * (via wp_save_revisioned_meta_fields) captures the already-restored
+	 * state. If meta were restored after, the new revision would snapshot
+	 * the stale pre-rollback values, making diffs appear empty.
 	 *
 	 * @param int $post_id         The post ID to restore.
 	 * @param int $pre_revision_id The revision ID to restore from.
@@ -202,7 +204,16 @@ class NRE_Migration_Rollback {
 		// 2. Restore post type from the pre-migration revision.
 		$this->restore_post_type( $post_id, $pre_revision_id );
 
-		// 3. Restore core fields + registered meta (creates a new revision).
+		// 3. Restore all tracked meta from the revision.
+		// This must happen BEFORE wp_restore_post_revision() because that
+		// function calls wp_update_post() which creates a new revision.
+		// The new revision snapshots the parent's current meta via
+		// wp_save_revisioned_meta_fields — so the meta must already be
+		// restored for the snapshot to be correct.
+		$this->restore_meta( $post_id, $pre_revision_id );
+
+		// 4. Restore core fields (title, content, excerpt, etc.).
+		// This creates a new revision that captures the full restored state.
 		$result = wp_restore_post_revision( $pre_revision_id );
 
 		if ( ! $result || is_wp_error( $result ) ) {
@@ -250,6 +261,71 @@ class NRE_Migration_Rollback {
 
 		if ( $stored_type && get_post_type( $post_id ) !== $stored_type ) {
 			set_post_type( $post_id, $stored_type );
+		}
+	}
+
+	/**
+	 * Restore all tracked meta from the pre-migration revision to the post.
+	 *
+	 * Reads every meta row stored on the revision directly from the database
+	 * (bypassing object cache) and writes it to the parent post. NRE internal
+	 * meta (migration tags, taxonomy snapshots, post type) is excluded since
+	 * those are handled by dedicated restore methods or are revision-only data.
+	 *
+	 * @param int $post_id     The post ID.
+	 * @param int $revision_id The revision ID to restore meta from.
+	 */
+	private function restore_meta( $post_id, $revision_id ) {
+		global $wpdb;
+
+		// Read all meta directly from the revision's own rows in postmeta.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$revision_meta = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d",
+				$revision_id
+			)
+		);
+
+		if ( empty( $revision_meta ) ) {
+			return;
+		}
+
+		// Collect meta values per key (a key can have multiple rows).
+		$meta_by_key = [];
+		foreach ( $revision_meta as $row ) {
+			$meta_by_key[ $row->meta_key ][] = $row->meta_value;
+		}
+
+		// Keys that are NRE internal — stored on revisions for NRE's own
+		// tracking but should not be copied to the parent post.
+		$skip_prefixes = [ '_nre_migration_', NRE_TAX_META_PREFIX ];
+		$skip_exact    = [ '_nre_post_type' ];
+
+		foreach ( $meta_by_key as $meta_key => $values ) {
+			// Skip NRE internal meta.
+			if ( in_array( $meta_key, $skip_exact, true ) ) {
+				continue;
+			}
+
+			$skip = false;
+			foreach ( $skip_prefixes as $prefix ) {
+				if ( 0 === strpos( $meta_key, $prefix ) ) {
+					$skip = true;
+					break;
+				}
+			}
+			if ( $skip ) {
+				continue;
+			}
+
+			// Clear existing values on the parent post, then write revision values.
+			delete_post_meta( $post_id, $meta_key );
+			foreach ( $values as $raw_value ) {
+				// Values from DB are raw (serialized if complex). Use add_metadata
+				// with wp_slash to match how _wp_copy_post_meta works.
+				add_metadata( 'post', $post_id, $meta_key, wp_slash( maybe_unserialize( $raw_value ) ) );
+			}
 		}
 	}
 }

--- a/tests/test-class-nre-migration-rollback.php
+++ b/tests/test-class-nre-migration-rollback.php
@@ -321,6 +321,117 @@ class Test_NRE_Migration_Rollback extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 1, $result['skipped'] );
 	}
 
+	public function test_rollback_post_restores_meta() {
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Set pre-migration meta.
+		update_post_meta( $post_id, 'seo_title', 'Original SEO Title' );
+		update_post_meta( $post_id, '_thumbnail_id', 42 );
+
+		// Pre-migration revision (meta is snapshotted by WP's revisioned meta).
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Pre-migration',
+			]
+		);
+
+		// Migration: change meta.
+		NRE_Migration_Context::start( 'Meta Rollback' );
+		$context = NRE_Migration_Context::get_context();
+
+		update_post_meta( $post_id, 'seo_title', 'Migrated SEO Title' );
+		update_post_meta( $post_id, '_thumbnail_id', 99 );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Migrated',
+			]
+		);
+
+		NRE_Migration_Context::stop();
+
+		// Verify migration changed the meta.
+		$this->assertSame( 'Migrated SEO Title', get_post_meta( $post_id, 'seo_title', true ) );
+
+		$this->rollback->rollback_post( $post_id, 'Meta Rollback', $context['timestamp'] );
+
+		// Meta should be restored to pre-migration values.
+		$this->assertSame( 'Original SEO Title', get_post_meta( $post_id, 'seo_title', true ) );
+		$this->assertEquals( 42, get_post_meta( $post_id, '_thumbnail_id', true ) );
+	}
+
+	public function test_rollback_revision_captures_restored_meta() {
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		update_post_meta( $post_id, 'seo_title', 'Original SEO' );
+
+		// Pre-migration revision.
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Pre-migration',
+			]
+		);
+
+		// Migration: change meta.
+		NRE_Migration_Context::start( 'Revision Meta Test' );
+		$context = NRE_Migration_Context::get_context();
+
+		update_post_meta( $post_id, 'seo_title', 'Migrated SEO' );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Migrated',
+			]
+		);
+
+		NRE_Migration_Context::stop();
+
+		$this->rollback->rollback_post( $post_id, 'Revision Meta Test', $context['timestamp'] );
+
+		// The newest revision (created by rollback) should have the restored meta,
+		// not the stale pre-rollback value.
+		$revisions    = wp_get_post_revisions( $post_id, [ 'order' => 'DESC' ] );
+		$rollback_rev = reset( $revisions );
+
+		$rev_seo = get_post_meta( $rollback_rev->ID, 'seo_title', true );
+		$this->assertSame( 'Original SEO', $rev_seo );
+	}
+
+	public function test_rollback_does_not_copy_nre_internal_meta() {
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Pre-migration revision.
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Pre-migration',
+			]
+		);
+
+		// Migration.
+		NRE_Migration_Context::start( 'Internal Meta Test' );
+		$context = NRE_Migration_Context::get_context();
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Migrated',
+			]
+		);
+
+		NRE_Migration_Context::stop();
+
+		$this->rollback->rollback_post( $post_id, 'Internal Meta Test', $context['timestamp'] );
+
+		// NRE internal meta should NOT be copied to the parent post.
+		$this->assertEmpty( get_post_meta( $post_id, '_nre_migration_name', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_nre_migration_ts', true ) );
+	}
+
 	public function test_rollback_creates_new_revision() {
 		$data = $this->create_migrated_post();
 

--- a/tests/test-class-nre-migration-rollback.php
+++ b/tests/test-class-nre-migration-rollback.php
@@ -401,6 +401,41 @@ class Test_NRE_Migration_Rollback extends WP_UnitTestCase {
 		$this->assertSame( 'Original SEO', $rev_seo );
 	}
 
+	public function test_rollback_deletes_meta_added_during_migration() {
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Pre-migration revision (no extra_field meta exists yet).
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Pre-migration',
+			]
+		);
+
+		// Migration: add a brand-new meta key.
+		NRE_Migration_Context::start( 'Added Meta Rollback' );
+		$context = NRE_Migration_Context::get_context();
+
+		update_post_meta( $post_id, 'extra_field', 'migration-only value' );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Migrated',
+			]
+		);
+
+		NRE_Migration_Context::stop();
+
+		// Verify the meta was added.
+		$this->assertSame( 'migration-only value', get_post_meta( $post_id, 'extra_field', true ) );
+
+		$this->rollback->rollback_post( $post_id, 'Added Meta Rollback', $context['timestamp'] );
+
+		// The meta key that was added during migration should be removed.
+		$this->assertEmpty( get_post_meta( $post_id, 'extra_field', true ) );
+	}
+
 	public function test_rollback_does_not_copy_nre_internal_meta() {
 		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
 


### PR DESCRIPTION
## Summary
- Add `restore_meta()` method that reads all meta from the pre-migration revision via direct DB query, filters out NRE internal keys (`_nre_migration_*`, `_nre_tax_*`, `_nre_post_type`), and writes to the parent post
- Reorder `execute_rollback()`: taxonomies → post type → **meta** → `wp_restore_post_revision()` so the rollback revision captures correct restored values
- Previously, meta was not restored at all, and the ordering meant the rollback revision would snapshot stale pre-rollback data

## Test plan
- [x] `test_rollback_post_restores_meta` — verifies `seo_title` and `_thumbnail_id` are restored to pre-migration values
- [x] `test_rollback_revision_captures_restored_meta` — verifies the rollback revision has the correct restored meta (not stale values)
- [x] `test_rollback_does_not_copy_nre_internal_meta` — verifies NRE internal meta keys are not copied to the parent post

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)