### PR TITLE
Add before_update/after_update helpers for raw SQL migration tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ wp_set_post_terms( $post_id, $terms, 'category' );
 NRE_Migration_Context::stop();
 ```
 
+For migrators that use raw `$wpdb` queries (which bypass WordPress hooks), use the `before_update`/`after_update` helpers to manually create revisions:
+
+```php
+NRE_Migration_Context::start( 'Raw SQL migration' );
+
+NRE_Migration_Context::before_update( $post_id ); // Creates untagged baseline revision.
+$wpdb->update( $wpdb->posts, [ 'post_content' => 'New content' ], [ 'ID' => $post_id ] );
+NRE_Migration_Context::after_update( $post_id );  // Creates tagged migration revision.
+
+NRE_Migration_Context::stop();
+```
+
 What this does:
 
 - Every revision created between `start()` and `stop()` is tagged with the migration name and a Unix timestamp in revision meta.
@@ -55,6 +67,8 @@ What this does:
 | `NRE_Migration_Context::start( string $name )` | Begin a migration context. |
 | `NRE_Migration_Context::stop()` | End the current migration context. |
 | `NRE_Migration_Context::get_context()` | Returns `array{name: string, timestamp: int}` or `null` if inactive. |
+| `NRE_Migration_Context::before_update( int $post_id )` | Create an untagged baseline revision before a raw SQL update. Only creates one if the post has no revisions yet. No-op outside a migration context. |
+| `NRE_Migration_Context::after_update( int $post_id )` | Create a tagged migration revision after a raw SQL update. Clears post cache first so the revision captures the current DB state. No-op outside a migration context. |
 
 ## Filters Reference
 

--- a/includes/class-nre-migration-context.php
+++ b/includes/class-nre-migration-context.php
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   NRE_Migration_Context::start( 'Batch import 2024-Q3 articles' );
- *   // ... wp_update_post() calls ...
+ *   // ... wp_update_post() or before_update()/after_update() around raw $wpdb ...
  *   NRE_Migration_Context::stop();
  *
  * @package Newspack_Revisions_Enhanced
@@ -179,6 +179,49 @@ class NRE_Migration_Context {
 		update_term_meta( self::$term_id, '_nre_migration_ts', self::$timestamp );
 
 		return self::$term_id;
+	}
+
+	/**
+	 * Create an untagged baseline revision before the migration modifies a post.
+	 *
+	 * Suppresses migration tagging so the baseline isn't marked as a migration
+	 * revision. Only creates a revision if the post has none yet.
+	 *
+	 * @param int $post_id The post about to be modified.
+	 */
+	public static function before_update( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
+			return;
+		}
+
+		$revisions = wp_get_post_revisions( $post_id, [ 'posts_per_page' => 1 ] );
+		if ( ! empty( $revisions ) ) {
+			return;
+		}
+
+		// Suppress tagging so the baseline revision is clean.
+		remove_action( '_wp_put_post_revision', [ __CLASS__, 'save_migration_meta' ], 5 );
+		wp_save_post_revision( $post_id );
+		add_action( '_wp_put_post_revision', [ __CLASS__, 'save_migration_meta' ], 5, 2 );
+	}
+
+	/**
+	 * Create a tagged migration revision after a raw SQL update.
+	 *
+	 * Clears the post cache so the revision captures the updated state.
+	 * The revision is automatically tagged by save_migration_meta.
+	 *
+	 * @param int $post_id The post that was just modified.
+	 */
+	public static function after_update( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
+			return;
+		}
+
+		clean_post_cache( $post_id );
+		wp_save_post_revision( $post_id );
 	}
 
 	/**

--- a/includes/class-nre-migration-context.php
+++ b/includes/class-nre-migration-context.php
@@ -190,6 +190,10 @@ class NRE_Migration_Context {
 	 * @param int $post_id The post about to be modified.
 	 */
 	public static function before_update( $post_id ) {
+		if ( null === self::$name ) {
+			return;
+		}
+
 		$post = get_post( $post_id );
 		if ( ! $post || wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
 			return;
@@ -215,6 +219,10 @@ class NRE_Migration_Context {
 	 * @param int $post_id The post that was just modified.
 	 */
 	public static function after_update( $post_id ) {
+		if ( null === self::$name ) {
+			return;
+		}
+
 		$post = get_post( $post_id );
 		if ( ! $post || wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
 			return;

--- a/includes/class-nre-migration-context.php
+++ b/includes/class-nre-migration-context.php
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   NRE_Migration_Context::start( 'Batch import 2024-Q3 articles' );
- *   // ... wp_update_post() or before_update()/after_update() around raw $wpdb ...
+ *   // ... wp_update_post() or NRE_Migration_Context::before_update()/after_update() around raw $wpdb ...
  *   NRE_Migration_Context::stop();
  *
  * @package Newspack_Revisions_Enhanced

--- a/tests/test-class-nre-migration-context.php
+++ b/tests/test-class-nre-migration-context.php
@@ -311,6 +311,129 @@ class Test_NRE_Migration_Context extends WP_UnitTestCase {
 		$this->assertTrue( true );
 	}
 
+	public function test_before_update_creates_baseline_revision() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Delete any auto-created revisions so the post has none.
+		$revisions = wp_get_post_revisions( $post_id );
+		foreach ( $revisions as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+		$this->assertEmpty( wp_get_post_revisions( $post_id ) );
+
+		NRE_Migration_Context::start( 'Before Update Test' );
+		NRE_Migration_Context::before_update( $post_id );
+
+		$revisions = wp_get_post_revisions( $post_id );
+		$this->assertCount( 1, $revisions );
+
+		// The baseline revision should NOT be tagged with migration meta.
+		$rev  = reset( $revisions );
+		$name = get_metadata( 'post', $rev->ID, '_nre_migration_name', true );
+		$this->assertEmpty( $name );
+
+		NRE_Migration_Context::stop();
+	}
+
+	public function test_before_update_skips_when_revisions_exist() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Force a revision to exist.
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => 'Revision 1',
+			]
+		);
+
+		$count_before = count( wp_get_post_revisions( $post_id ) );
+
+		NRE_Migration_Context::start( 'Before Update Skip Test' );
+		NRE_Migration_Context::before_update( $post_id );
+
+		$count_after = count( wp_get_post_revisions( $post_id ) );
+		$this->assertSame( $count_before, $count_after );
+
+		NRE_Migration_Context::stop();
+	}
+
+	public function test_after_update_creates_tagged_revision() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		NRE_Migration_Context::start( 'After Update Test' );
+
+		// Simulate a raw SQL update by directly modifying the post.
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->posts,
+			[ 'post_content' => 'Updated via raw SQL' ],
+			[ 'ID' => $post_id ]
+		);
+
+		NRE_Migration_Context::after_update( $post_id );
+		NRE_Migration_Context::stop();
+
+		// The newest revision should be tagged.
+		$revisions = wp_get_post_revisions( $post_id, [ 'order' => 'DESC' ] );
+		$latest    = reset( $revisions );
+
+		$name = get_metadata( 'post', $latest->ID, '_nre_migration_name', true );
+		$this->assertSame( 'After Update Test', $name );
+
+		// The revision should capture the updated content.
+		$this->assertSame( 'Updated via raw SQL', $latest->post_content );
+	}
+
+	public function test_before_after_update_full_workflow() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original content' ] );
+
+		// Delete auto-revisions to start clean.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		NRE_Migration_Context::start( 'Full Workflow' );
+
+		NRE_Migration_Context::before_update( $post_id );
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->posts,
+			[ 'post_content' => 'Migrated content' ],
+			[ 'ID' => $post_id ]
+		);
+
+		NRE_Migration_Context::after_update( $post_id );
+		NRE_Migration_Context::stop();
+
+		$revisions = wp_get_post_revisions( $post_id, [ 'order' => 'ASC' ] );
+		$this->assertGreaterThanOrEqual( 2, count( $revisions ) );
+
+		// First revision: untagged baseline.
+		$baseline      = reset( $revisions );
+		$baseline_name = get_metadata( 'post', $baseline->ID, '_nre_migration_name', true );
+		$this->assertEmpty( $baseline_name );
+		$this->assertSame( 'Original content', $baseline->post_content );
+
+		// Last revision: tagged migration.
+		$migration      = end( $revisions );
+		$migration_name = get_metadata( 'post', $migration->ID, '_nre_migration_name', true );
+		$this->assertSame( 'Full Workflow', $migration_name );
+		$this->assertSame( 'Migrated content', $migration->post_content );
+	}
+
 	public function test_start_stop_lifecycle() {
 		$this->assertNull( NRE_Migration_Context::get_context() );
 

--- a/tests/test-class-nre-migration-context.php
+++ b/tests/test-class-nre-migration-context.php
@@ -434,6 +434,25 @@ class Test_NRE_Migration_Context extends WP_UnitTestCase {
 		$this->assertSame( 'Migrated content', $migration->post_content );
 	}
 
+	public function test_before_after_update_noop_without_context() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$post_id = $this->factory->post->create( [ 'post_content' => 'Original' ] );
+
+		// Delete auto-revisions.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		// No start() call — context is inactive.
+		NRE_Migration_Context::before_update( $post_id );
+		NRE_Migration_Context::after_update( $post_id );
+
+		// No revisions should have been created.
+		$this->assertEmpty( wp_get_post_revisions( $post_id ) );
+	}
+
 	public function test_start_stop_lifecycle() {
 		$this->assertNull( NRE_Migration_Context::get_context() );
 


### PR DESCRIPTION
## Summary
- Add `before_update($post_id)` — creates an untagged baseline revision if the post has no revisions, suppressing migration tagging so it's clean
- Add `after_update($post_id)` — clears post cache and creates a tagged migration revision capturing the current (post-update) state
- These helpers allow migrators using raw `$wpdb` queries to participate in NRE revision tracking

## Test plan
- [x] `test_before_update_creates_baseline_revision` — baseline is created and untagged
- [x] `test_before_update_skips_when_revisions_exist` — no extra revision if one already exists
- [x] `test_after_update_creates_tagged_revision` — revision is tagged and captures updated content
- [x] `test_before_after_update_full_workflow` — end-to-end: baseline (untagged, original content) + migration (tagged, new content)

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)