### PR TITLE
Fix native revision screen showing empty diff for creation migrations

### DIFF
--- a/assets/js/nre-revisions.js
+++ b/assets/js/nre-revisions.js
@@ -94,6 +94,9 @@
 
 		/**
 		 * Get the sequential pairs for a migration's revisions.
+		 *
+		 * For "creation" migrations where the first revision is the very
+		 * first overall revision, from is null — there is no predecessor.
 		 */
 		function getMigrationPairs( migration ) {
 			var ids   = migration.revisionIds,
@@ -112,23 +115,25 @@
 					if ( idx > 0 ) {
 						fromRev = revisions.at( idx - 1 );
 					} else {
-						fromRev = rev;
+						fromRev = null;
 					}
 				} else {
 					fromRev = revisions.get( ids[ i - 1 ] );
 				}
 
-				if ( fromRev ) {
-					pairs.push( { from: fromRev, to: rev } );
-				}
+				pairs.push( { from: fromRev, to: rev } );
 			} );
 
 			return pairs;
 		}
 
 		function jumpToPair( pair ) {
-			model.set( { compareTwoMode: true } );
-			model.set( { from: pair.from, to: pair.to } );
+			if ( pair.from === null ) {
+				// Creation revision — compare from 0 (nothing) to show all content as additions.
+				model.set( { compareTwoMode: true, from: 0, to: pair.to } );
+			} else {
+				model.set( { compareTwoMode: true, from: pair.from, to: pair.to } );
+			}
 		}
 
 		function updateNav() {
@@ -165,10 +170,20 @@
 
 			var pairs = getMigrationPairs( migration );
 			if ( pairs.length > 0 ) {
-				jumpToPair( {
-					from: pairs[0].from,
-					to: pairs[ pairs.length - 1 ].to
-				} );
+				if ( pairs.length === 1 ) {
+					// Single revision — jump directly to it.
+					jumpToPair( pairs[0] );
+				} else if ( pairs[0].from === null ) {
+					// Creation migration with multiple revisions —
+					// show the first (creation) pair in slider mode.
+					jumpToPair( pairs[0] );
+				} else {
+					// Update migration — show full range in compareTwoMode.
+					jumpToPair( {
+						from: pairs[0].from,
+						to: pairs[ pairs.length - 1 ].to
+					} );
+				}
 				navIndex = 0;
 				updateNav();
 			}

--- a/assets/js/nre-revisions.js
+++ b/assets/js/nre-revisions.js
@@ -175,7 +175,7 @@
 					jumpToPair( pairs[0] );
 				} else if ( pairs[0].from === null ) {
 					// Creation migration with multiple revisions —
-					// show the first (creation) pair in slider mode.
+					// show the first (creation) pair compared against nothing.
 					jumpToPair( pairs[0] );
 				} else {
 					// Update migration — show full range in compareTwoMode.


### PR DESCRIPTION
## Summary
- `getMigrationPairs()`: set `from: null` instead of `from: rev` when a migration's first revision has no predecessor
- `jumpToPair()`: when `from === null`, use `compareTwoMode: true` with `from: 0` — WP's diff AJAX endpoint treats this as "compare against nothing," showing all content as additions
- Sidebar click handler: for single-revision or creation migrations, jump directly to the pair instead of synthesizing a range that would also produce from===to

## Test plan
- [ ] Manual: navigate to `revision.php?from=X&to=Y` for a post with a creation migration, click the creation migration in the sidebar — should show full diff (featured image, title, content, meta, taxonomies) all as additions
- [ ] Manual: verify non-creation migrations still navigate correctly with compareTwoMode range
- Verified with Playwright automation during development

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)